### PR TITLE
Update requirements.txt

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,3 @@
-﻿azure-cli-core==2.5.1
+azure-cli-core==2.5.1
 azure-mgmt-iotcentral==4.1.0
+azure-common==1.1.26


### PR DESCRIPTION
add missing dependencies, azure-common, good catch @rahulch95 !

Or else people will have issue like

```
λ python .\run.py
Traceback (most recent call last):
  File ".\run.py", line 5, in <module>
    from azure.common.credentials import UserPassCredentials, get_azure_cli_credentials
ModuleNotFoundError: No module named 'azure.common'
```