### PR TITLE
Updating Go Sample for 2021-06-01 SDK Release

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -16,7 +16,7 @@ go get -u github.com/dimchansky/utfbom
 go get -u github.com/mitchellh/go-homedir
 go get -u golang.org/x/crypto/pkcs12
 go get -u github.com/Azure/azure-sdk-for-go
-go get -u github.com/Azure/azure-sdk-for-go/services/iotcentral/mgmt/2018-09-01/iotcentral
+go get -u github.com/Azure/azure-sdk-for-go/services/iotcentral/mgmt/2021-06-01/iotcentral
 go build
 ```
 
@@ -27,4 +27,4 @@ Make sure you head over to the main.go file to change the configuration to the o
 .\go.exe
 ```
 
-Ever wonder what Azure SDK for Go provide in terms of iotcentral? Check [this](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/services/iotcentral/mgmt/2018-09-01/iotcentral) out.
+Ever wonder what Azure SDK for Go provide in terms of iotcentral? Check [this](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/services/iotcentral/mgmt/2021-06-01/iotcentral) out.

--- a/go/README.md
+++ b/go/README.md
@@ -7,6 +7,7 @@ Sample code for using [iotcentral](https://github.com/Azure/azure-sdk-for-go/rel
 ### Prerequisites
 - [Go](https://golang.org/doc/install)
 - A resource group called **myResourceGroup** in your Azure subscription
+- Update main.go file with subscription id, client id, and tenant id information to allow for authorization.
 
 ### Installation
 To begin, simply clone this repository onto your local machine and run the following to install all the necessary dependencies.
@@ -24,7 +25,7 @@ go build
 Make sure you head over to the main.go file to change the configuration to the one that is shown on your [Microsoft Azure Portal](https://portal.azure.com).
 
 ```
-.\go.exe
+go run .\main.go
 ```
 
 Ever wonder what Azure SDK for Go provide in terms of iotcentral? Check [this](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/services/iotcentral/mgmt/2021-06-01/iotcentral) out.

--- a/go/main.go
+++ b/go/main.go
@@ -37,8 +37,8 @@ func main() {
 		operationsClient.Authorizer = authorizer
 	}
 
-	resourceDisplayName := "chris-test2"
-	resourceDomainName := "kjdfksnmsd"
+	resourceDisplayName := "resource-display-name"
+	resourceDomainName := "resource-unique-url-id"
 	resourceGroup := "myResourceGroup"
 	location := "eastus2"
 	operationInputs := iotcentral.OperationInputs{

--- a/go/main.go
+++ b/go/main.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Azure/azure-sdk-for-go/services/iotcentral/mgmt/2018-09-01/iotcentral"
+	"github.com/Azure/azure-sdk-for-go/services/iotcentral/mgmt/2021-06-01/iotcentral"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 )
 
 func main() {
-	subscriptionID := ""
+	subscriptionID := "add-subscription-id-here"
 	ioTCentralClient := iotcentral.NewAppsClient(subscriptionID)
 	operationsClient := iotcentral.NewOperationsClient(subscriptionID)
 
@@ -24,11 +24,12 @@ func main() {
 	// You also need to set the Redirect URIs, otherwise, it won't work.
 	// Check out this article in case you are interested in other ways to authericate https://docs.microsoft.com/azure/go/azure-sdk-go-authorization
 	// sample code for Authentication with Azure, check out this readme, https://github.com/Azure/azure-sdk-for-go#authentication
-	applicationID := "" // client id
-	directoryID := ""   // tenant id
+	applicationID := "add-app-id-here" // client id
+	directoryID := "add-directory-id-here"   // tenant id
 	deviceConfig := auth.NewDeviceFlowConfig(applicationID, directoryID)
 	authorizer, authorizerErr := deviceConfig.Authorizer()
 	if authorizerErr != nil {
+		fmt.Println("Error authorizing.")
 		fmt.Println(authorizerErr)
 		os.Exit(1)
 	} else {
@@ -36,10 +37,10 @@ func main() {
 		operationsClient.Authorizer = authorizer
 	}
 
-	resourceDisplayName := "some app name"
-	resourceDomainName := "some-app-name"
+	resourceDisplayName := "chris-test2"
+	resourceDomainName := "kjdfksnmsd"
 	resourceGroup := "myResourceGroup"
-	location := "unitedstates"
+	location := "eastus2"
 	operationInputs := iotcentral.OperationInputs{
 		Name: &resourceDomainName,
 	}
@@ -58,7 +59,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	appSku := iotcentral.ST2
+	appInvalidSkuInfo := iotcentral.AppSkuInfo{
+		Name: "S1",
+	}
+	appSku := iotcentral.AppSkuST2
 	appSkuInfo := iotcentral.AppSkuInfo{
 		Name: appSku,
 	}
@@ -66,11 +70,32 @@ func main() {
 		DisplayName: &resourceDisplayName,
 		Subdomain:   &resourceDomainName,
 	}
+	appIdentity := iotcentral.SystemAssignedServiceIdentity{
+		Type: iotcentral.SystemAssignedServiceIdentityTypeSystemAssigned,
+	}
 	app := iotcentral.App{
 		AppProperties: &appProperties,
 		Sku:           &appSkuInfo,
 		Name:          &resourceDomainName,
 		Location:      &location,
+		Identity:      &appIdentity,
+	}
+	appInvalidSku := iotcentral.App{
+		AppProperties: &appProperties,
+		Sku:           &appInvalidSkuInfo,
+		Name:          &resourceDomainName,
+		Location:      &location,
+		Identity:      &appIdentity,
+	}
+
+	// fail to create invalid sku app
+	failCreateResult, failCreateErr := ioTCentralClient.CreateOrUpdate(context.Background(), resourceGroup, resourceDomainName, appInvalidSku)
+	if failCreateErr != nil {
+		fmt.Println(failCreateResult.Status() + " to create/update invalid app")
+		fmt.Println(failCreateErr)
+	} else {
+		fmt.Println(failCreateResult.Status() + " to create/update invalid app")
+		os.Exit(1)
 	}
 
 	// create app
@@ -150,11 +175,11 @@ func main() {
 	}
 
 	// delete app
-	// deleteAppResult, deleteAppErr := ioTCentralClient.Delete(context.Background(), resourceGroup, resourceDomainName)
-	// if deleteAppErr != nil {
-	// 	fmt.Println(deleteAppErr)
-	// 	os.Exit(1)
-	// } else {
-	// 	fmt.Println(deleteAppResult.Status() + " to delete app")
-	// }
+	deleteAppResult, deleteAppErr := ioTCentralClient.Delete(context.Background(), resourceGroup, resourceDomainName)
+	if deleteAppErr != nil {
+		fmt.Println(deleteAppErr)
+		os.Exit(1)
+	} else {
+		fmt.Println(deleteAppResult.Status() + " to delete app")
+	}
 }


### PR DESCRIPTION
The Go sample has been updated for the 2021-06-01 release of the IoT Central SDK. The sample has been updated to validate system-assigned managed identity, check that the invalid SKU of "S1" throws a failure, and validate regional locations (i.e., "eastus") instead of geographies.